### PR TITLE
Migrate AI docs to @claude mention trigger model

### DIFF
--- a/.agents/rules/project.md
+++ b/.agents/rules/project.md
@@ -1,0 +1,71 @@
+# Project Rules
+
+## Branch Strategy
+
+```
+main  ← developer only, production-ready, never touched by the agent
+ └── dev  ← integration branch, PRs are merged here by the developer
+      └── {issue-number}-{description}  ← all agent work happens here
+```
+
+- **`main`**: managed by the developer only. Never commit or push to `main`.
+- **`dev`**: the integration branch. Never commit or push directly to `dev`. All work reaches `dev` via a PR.
+- **Feature branches**: always branch off `dev`, named `{issue-number}-{short-kebab-description}` (e.g. `42-user-registration-form`). All PRs target `dev`.
+- **Branch deletion**: do not delete branches manually. The repository is configured to delete head branches automatically after a PR is merged.
+
+## GitHub Workflow
+
+The developer interfaces via GitHub only — they do not have access to the local machine. All progress must be visible via commits and PRs on the remote.
+
+- When picking up a GH issue, follow the "Implementing an Issue" steps in `CLAUDE.md`
+- When responding to PR review comments, follow the "Responding to PR Reviews" steps in `CLAUDE.md`
+- Never leave work uncommitted and unpushed at the end of a session
+- Never merge your own PR
+
+## Communication
+
+All discussion, questions, and remarks happen in the PR — not only in chat responses.
+
+- If you have a question about the work, post it as a comment on the relevant PR before waiting for a response
+- If you want to flag a concern, decision, or trade-off, comment on the relevant line or post a general PR comment
+- If you are making a design decision that is not explicitly covered by the spec, note it in a PR comment so the developer can review it
+- A chat reply alone is not enough — the PR is the record of what was agreed and why
+
+## Documentation
+
+- Update `CLAUDE.md` any time the project structure, stack, or running instructions change.
+- Update `docs/specs/` when an architectural decision or workflow changes significantly.
+- Update `.agents/rules/project.md` (this file) when a new coding convention or behavioural rule is agreed.
+- Do not create new doc files for one-off notes — commit messages are the right place for those.
+- If any doc describes something that no longer matches reality, fix it in the same session it was found.
+
+## Backend
+
+- Follow the 7-layer architecture — see `docs/specs/backend-architecture.md` for the full structure and dependency rules.
+- Follow SRP and the orchestrator pattern — see `docs/specs/backend-srp.md`.
+- All new API endpoints must be registered within the `.WithOpenApi()` chain in `Program.cs`.
+- Request models (`*Request`) must never include server-managed fields (`Id`, `CreatedAt`, `IsVerified`).
+- Routes live in `Routes/` as extension methods — do not add routes directly in `Program.cs`.
+- Service methods accept and return interfaces, not concrete types.
+- After adding or changing a backend endpoint, run `npm run codegen` in `frontend/` to regenerate `generatedApi.ts`.
+
+## Frontend
+
+- Never hand-edit `src/api/generatedApi.ts` — it is always overwritten by `npm run codegen`.
+- Custom endpoints not covered by the OpenAPI schema go in a separate file (e.g. `src/api/customApi.ts`).
+- Components should be small and focused.
+- **Styling**: use SCSS. Each component gets a co-located `.scss` file (e.g. `Navbar.tsx` + `Navbar.scss`). Shared design tokens, resets, and utilities live in `src/styles/`. Do not write component-specific styles in global files, and do not use inline styles where a class exists.
+
+## Testing
+
+- Follow the testing strategy in `docs/specs/testing-strategy.md`.
+- Write tests before implementation (TDD).
+- Unit tests: one class at a time, all dependencies mocked.
+- In-process integration tests: real service implementations wired via DI, only external I/O mocked — no test database.
+- Frontend: Vitest + React Testing Library.
+
+## Infrastructure
+
+- `deploy.sh` and `helm/values.yaml` contain app-specific values — flag these to the developer when onboarding a new project.
+- `docker-build-push.yml` is triggered manually only (`workflow_dispatch`).
+- `ci.yml` runs on pull requests only and validates that the code builds — it does not push images.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,48 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr *)'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,4 @@
-# CLAUDE.md — web-template
-
-A `dotnet new` monorepo template for .NET 10 + React 19 projects. Every new project you start should be scaffolded from this template.
+# CLAUDE.md — macro-metrics
 
 ## Tech Stack
 
@@ -32,10 +30,10 @@ A `dotnet new` monorepo template for .NET 10 + React 19 projects. Every new proj
 │       ├── store/                 # Redux store
 │       └── styles/                # Global SCSS: design tokens, resets, utilities
 ├── scripts/init.mjs               # First-run onboarding: generates appsettings + .env
+├── scripts/init-issues.mjs        # Scaffolds initial SDD issues on GitHub
 ├── helm/                          # Helm chart for Kubernetes deployment
-├── deploy.sh                      # Local CD: build, push images, restart K8s deployments
 ├── docs/specs/                    # Architecture decisions and how-to guides
-└── .agents/                       # AI rules and workflows
+└── .agents/                       # Coding conventions and workflow rules
 ```
 
 ## Key Docs
@@ -47,10 +45,8 @@ A `dotnet new` monorepo template for .NET 10 + React 19 projects. Every new proj
 | `docs/specs/openapi-codegen.md` | OpenAPI → RTK Query codegen workflow |
 | `docs/specs/testing-strategy.md` | Unit tests, in-process integration tests, Vitest |
 | `docs/specs/sdd-workflow.md` | 7-phase Spec Driven Development process |
+| `docs/ai-workflow.md` | End-to-end AI-assisted project workflow and phase structure |
 | `.agents/rules/project.md` | Coding conventions, branch strategy, GitHub workflow rules |
-| `.claude/skills/action-issue/SKILL.md` | How to pick up and implement a GH issue |
-| `.claude/skills/respond-to-pr/SKILL.md` | How to respond to PR review comments |
-| `.claude/skills/pr-readiness/SKILL.md` | Pre-PR checklist — naming, AutoMapper, typed results, architecture |
 
 ## Backend Architecture Quick Reference
 
@@ -71,7 +67,6 @@ A `dotnet new` monorepo template for .NET 10 + React 19 projects. Every new proj
 - **Service interfaces** — always return interfaces (`IRatio`), never concrete types
 - **Route handlers** — named static methods; typed results (`Ok<T>` / `Results<T1,T2>`); map via `IMapper`; no business logic
 - **AutoMapper** — `WebApi/Mapper.cs` for Domain→Data (API boundary); `Services/Mapper.cs` for Entity→Domain (DB boundary)
-- **Always run `.claude/skills/pr-readiness/SKILL.md` before opening a PR**
 
 ## Running Locally
 
@@ -105,30 +100,288 @@ cd backend && dotnet ef database update \
 
 CI runs on PRs only (`ci.yml`). Image builds are manual (`docker-build-push.yml`, `workflow_dispatch`).
 
+## How to Trigger Claude
+
+Tag `@claude` in any issue or PR comment. Claude reads the full thread before acting.
+
+Examples:
+- `@claude the spec questionnaire in [1c] is filled in — please raise the spec PR`
+- `@claude implement this issue`
+- `@claude address the review comments on this PR`
+- `@claude [2a] is ready — please create the design issues`
+
+If you want a plan or have a question, just ask. If you want implementation, say so.
+
 ## GitHub Conventions
 
 - **Branch target**: All PRs target `dev`. Never target `main` — `dev` → `main` is a human-only action.
-- **PR assignment**: Every PR the AI raises must be assigned to `jemmy8oy`.
-- **Issue assignment**: Every issue the AI acts on must be assigned to `jemmy8oy`.
-- **Issue linking**: Every PR body must include `Closes #N`. The AI also comments on the issue: *🤖 PR raised: #N — please review when ready.*
-- **Labels**: After pushing changes and commenting on a PR, always apply the `waiting-for-human` label and remove `waiting-for-ai`. Apply `waiting-for-ai` when handing back to the AI (e.g. after raising a review comment).
+- **PR assignment**: Every PR Claude raises must be assigned to the repo owner.
+- **Issue assignment**: Every issue Claude acts on must be assigned to the repo owner.
+- **Issue linking**: Every PR body must include `Closes #N`. Claude also comments on the issue: *🤖 PR raised: #N — please review when ready.*
 
-## [2] Design Issue Template
+## Notification Rule (mandatory)
 
-When creating `[2]` UI/UX design issues (via `[2a]`), use this structure:
+Always assign the repository owner to every issue and PR:
+- `gh issue create ... --assignee $(gh repo view --json owner --jq .owner.login)`
+- `gh pr create   ... --assignee $(gh repo view --json owner --jq .owner.login)`
+- Finding owner: Use `gh repo view --json owner --jq .owner.login`. Cache it — don't call multiple times.
+- Verification: After creating issues/PRs, run `gh issue view <N> --json assignees` to confirm.
 
+## Assumptions & Decisions (mandatory for all AI-raised PRs)
+
+Every PR Claude raises must include a populated "Assumptions & Decisions" section in the PR body:
+
+```markdown
+## Assumptions & Decisions
+
+> Any assumption made during implementation that was not explicitly specified in the issue or spec.
+> If you disagree with any item, comment and tag `@claude` with the correction — Claude will revise.
+
+| # | Assumption | Rationale | If incorrect... |
+|---|---|---|---|
+| 1 | | | |
 ```
-Design the <feature name> for <product name>.
 
-**Feature:** `docs/features/<feature-file>.md`
+Rules:
+- Minimum one row. Use "N/A — no ambiguous assumptions" only if genuinely nothing was assumed.
+- Always surface: branch target choice, external API/series ID choices, CSS/styling strategy, database decisions.
+- Never leave the table blank.
 
-**Open UX questions to resolve:**
-- <question from feature file>
-- <question from feature file>
+## Implementing an Issue
 
-**Deliverables (in the design PR):**
-- [ ] ASCII mockup for each meaningful page/component state
-- [ ] ASCII mockup for each key interaction state (loading, error, empty)
-- [ ] Mermaid workflow diagram for each key user action
-- [ ] All open UX questions answered
+When tagged to implement a GitHub issue:
+
+### 1. Read the full issue before starting
+Read the issue body AND all comments. The comments contain the negotiated spec. Do not start until everything is read.
+
+### 2. Create a branch off dev
+```bash
+git checkout dev && git pull
+git checkout -b {issue-number}-{short-kebab-description}
 ```
+
+### 3. Implement with TDD
+Follow the top-down TDD flow in `docs/specs/testing-strategy.md`. Write tests before implementation. Commit after each meaningful unit of work.
+
+### 4. Format before every commit
+```bash
+# C# files
+cd backend && dotnet format
+
+# TypeScript / CSS files
+npx prettier --write "frontend/src/**/*.{ts,tsx,css}"
+```
+
+### 5. Push frequently
+Push after every meaningful commit. The developer cannot see work until it is on the remote.
+```bash
+git push -u origin {issue-number}-{description}
+```
+
+### 6. Open a PR targeting dev
+```bash
+gh pr create --base dev --title "..." --body "..."
+```
+PR body must include:
+- `Closes #N` to auto-close the issue on merge
+- Summary of what was implemented
+- Assumptions & Decisions table
+- Anything the reviewer needs to know to assess the work without running it locally
+
+### 7. Do not merge your own PR
+Leave it open for the developer to review. Comment on the issue: *🤖 PR raised: #N — please review when ready.*
+
+## Responding to PR Reviews
+
+When tagged to address PR review comments:
+
+### 1. Read all comments before making any changes
+Read every comment on the PR before touching code. Understand the full picture first.
+
+### 2. Assess each comment
+- **Implement** — clear request, agreed upon
+- **Ask for clarification** — ambiguous; reply on the comment thread before acting, don't guess
+- **Push back with reasoning** — if you disagree, explain why in a comment before implementing
+
+### 3. Make focused commits per change
+Address comments in separate, focused commits where possible.
+```bash
+git commit -m "Address PR feedback: extract validation into separate method (#42)"
+```
+
+### 4. Push after every commit
+Do not batch everything and push once at the end. The developer follows progress via the commit history.
+
+### 5. Reply to every comment on GitHub
+After pushing the relevant commit, reply explaining what changed and why. Do not leave comments unacknowledged.
+
+### 6. Post a summary comment when done
+Once all comments are addressed, post a single PR comment summarising what was changed and flagging anything still needing a decision.
+
+### 7. Do not re-request review or resolve conversations
+Leave that to the developer.
+
+## Pre-PR Checklist
+
+Run this checklist before raising any PR against backend changes.
+
+### 1. Naming Conventions
+
+| Check | Rule |
+|---|---|
+| DataModels use plain nouns | `Ratio`, not `RatioResponse` — use `*Response` only if the route constructs a meaningfully different shape |
+| `*Request` suffix | Only for inbound route bodies with non-trivial shape; never for query-string parameters |
+| DomainModels prefixed `Domain*` | `DomainRatio`, `DomainIndicator` — not plain nouns |
+| Entities suffixed `*Entity` | Reserved for EF Core entity classes in `EntityModels/` |
+
+### 2. Abstractions Project — Interfaces Only
+
+- [ ] No concrete types defined in `MacroMetrics.Abstractions`
+- [ ] Service interface methods return **interfaces**, not concrete types (`IRatio`, not `Ratio`)
+- [ ] `MacroMetrics.Abstractions.csproj` has **zero** `<ProjectReference>` entries to concrete projects
+
+### 3. Inheritance & Extension Pattern
+
+- [ ] Every `Domain*` class extends its `DataModels` counterpart (`DomainRatio : Ratio`)
+- [ ] `DataModels` classes implement the corresponding `Abstractions` interface (`Ratio : IRatio`)
+- [ ] Domain models in `MacroMetrics.DomainModels`, data models in `MacroMetrics.DataModels`
+
+### 4. Route Handlers
+
+- [ ] Handlers are **named static methods**, not inline lambdas
+- [ ] Return **typed results** — `Ok<T>`, `Results<Ok<T>, NotFound>` — never bare `IResult`
+- [ ] Mapping done via **AutoMapper** (`IMapper`), not manual helpers
+- [ ] No business logic in routes
+
+### 5. Service Layer
+
+- [ ] Service methods return interface types
+- [ ] No HTTP or serialisation concepts in services
+- [ ] Bogus/faker logic lives in `Services/`, never in `WebApi/`
+
+### 6. AutoMapper Profiles
+
+- [ ] `WebApi/Mapper.cs` — maps `Domain*` → DataModel (API boundary)
+- [ ] `Services/Mapper.cs` — maps `*Entity` → `Domain*` (DB boundary)
+- [ ] Both profiles discovered via `cfg.AddMaps(AppDomain.CurrentDomain.GetAssemblies())`
+
+### 7. Build Gate
+
+```bash
+cd backend && dotnet build
+```
+
+- [ ] **0 errors** before raising the PR
+
+## Code Formatting
+
+Format before every commit. CI enforces these on PRs.
+
+```bash
+# C# — run from repo root
+cd backend && dotnet format
+
+# TypeScript / CSS
+npx prettier --write "frontend/src/**/*.{ts,tsx,css}"
+```
+
+## Phase Guard Status Format
+
+When tagged on an orchestrator issue, check phase dependencies and post a concise status block if any checks are pending:
+
+```markdown
+## 🔍 Phase Check
+
+| Check | Status |
+|---|---|
+| Phase N dependencies | ⏳ #32, #34 still open — waiting |
+| Key decision from [1c] | ✅ "No DB for MVP" — EF Core items skipped |
+| External data sources | ⚠️ CAPE source unverified — flagging in spec |
+```
+
+Rules:
+- Maximum 3–5 rows — only include relevant checks
+- ✅ = confirmed, ⏳ = pending, ⚠️ = flagged
+- If all checks pass: proceed directly without posting the table
+
+## Clarification Protocol
+
+**Step 1: Can I make a sensible assumption?**
+- Yes → implement with the assumption, document it in the PR's Assumptions & Decisions table. **Do not block.**
+
+**Step 2: Is this a major architectural decision with no sensible default?**
+- Yes → post a single comment with the question + recommended default. Wait for a response before implementing.
+- No → treat as Step 1.
+
+Default behaviour: **Mixed** — assume minor/stylistic choices, ask only for major architectural decisions with no sensible default.
+
+Anti-patterns:
+- ❌ Asking the same question more than once
+- ❌ Blocking on minor choices (library patch version, variable names)
+- ❌ Posting multiple clarifying questions in separate comments — batch them into one
+
+## Issue Factories ([3b] and [5c])
+
+Issue factories are passes that create multiple downstream issues programmatically.
+
+### [3b] — Creates [4] frontend implementation issues
+
+Each [4] issue must include:
+- [ ] A single, clearly scoped frontend feature or component
+- [ ] Acceptance criteria referencing the BDD story from [3a]
+- [ ] A Testing section (mandatory AC)
+- [ ] A Visual Evidence section (mandatory AC)
+- [ ] `--assignee $(gh repo view --json owner --jq .owner.login)` (mandatory)
+
+### [5c] — Creates [6] backend implementation issues
+
+Each [6] issue must include:
+- [ ] A single, clearly scoped backend service or fetcher
+- [ ] Reference to the data source validation from [5a]
+- [ ] A Testing section (mandatory AC)
+- [ ] `--assignee $(gh repo view --json owner --jq .owner.login)` (mandatory)
+
+### Factory verification
+
+After each factory run:
+```bash
+gh issue list --repo $(gh repo view --json nameWithOwner --jq .nameWithOwner) --limit 30 --json number,assignees | python3 -c "import sys,json; [print(f'#{i[\"number\"]} — assignees: {[a[\"login\"] for a in i[\"assignees\"]]}') for i in json.load(sys.stdin)]"
+```
+
+## Testing Standards (mandatory)
+
+Before raising any PR, all tests must pass. Testing is never optional.
+
+- **Backend:** Write tests first (TDD). Run `dotnet test` — zero failures.
+- **Frontend:** Write tests spec-first. Run `npm test` — zero failures.
+- **Strategy + examples:** `docs/specs/testing-strategy.md`
+
+Never raise a PR with failing tests. If tests cannot be made to pass, flag this explicitly in the PR body and ask for guidance.
+
+## CSS Coding Standards
+
+- Always use CSS custom properties (`var(--colour-name)`) for colours, spacing, and typography. **Never hardcode colour values** (hex, rgb, hsl) directly in component CSS.
+- Define custom properties in `:root` or a `:global` scope block. Reference them everywhere else.
+- Acceptable: `color: var(--colour-primary);`
+- Not acceptable: `color: #1a1a2e;` or `color: rgb(26, 26, 46);`
+
+## Frontend PR Screenshots (mandatory)
+
+For any PR that modifies React components, pages, or CSS:
+
+1. Start the dev server: `npm run dev` or `npx serve dist`
+2. Capture: `npx playwright screenshot --full-page http://localhost:5173 pr-screenshot.png`
+3. Attach to the PR body: `![screenshot](./pr-screenshot.png)` or as a GitHub comment
+
+If Playwright is not available in the environment:
+- Note this explicitly in the PR body
+- Add a TODO: "Install Playwright in the bot container to enable automated screenshots"
+
+## Helm Scaffold Setup
+
+After creating a new project from this template, update `helm/values.yaml`:
+1. Set `fullnameOverride` to your app name (lowercase, hyphens — e.g. `my-app`)
+2. Set `apps[*].ingress.path` to `/{app-name}` (frontend) and `/{app-name}/api` (backend)
+3. The `balenthiran.co.uk` host, `balenthiran-tls` cert, and `registryPrefix` are shared — do not change them
+4. Add app-specific env vars / secrets as needed — none are pre-scaffolded
+5. Do NOT add `deploy.sh` — deployment is via `docker-build-push.yml` pipeline

--- a/docs/ai-workflow.md
+++ b/docs/ai-workflow.md
@@ -1,6 +1,6 @@
 # AI-Assisted Project Workflow
 
-This document describes the end-to-end workflow for projects bootstrapped from this template. It covers the full lifecycle from repository creation through to MVP launch, and defines conventions the AI agent follows throughout.
+This document describes the end-to-end workflow for projects bootstrapped from this template. It covers the full lifecycle from repository creation through to MVP launch, and defines conventions Claude follows throughout.
 
 ---
 
@@ -8,16 +8,16 @@ This document describes the end-to-end workflow for projects bootstrapped from t
 
 > No GitHub issues. These are one-off actions performed once when the project is created.
 
-1. Developer creates the GitHub repo and grants the bot access
-2. AI scaffolds the project from this template and pushes the initial commit
-3. AI creates all **initial issues** (see table below) with the `MVP` milestone
-4. Developer works through Phase 1 issues to configure the project
+1. Developer creates the GitHub repo
+2. Install the Claude GitHub App and add `CLAUDE_CODE_OAUTH_TOKEN` to repository secrets
+3. Run `node scripts/init-issues.mjs` to scaffold all initial SDD issues
+4. Work through Phase 1 issues to configure the project
 
 ---
 
 ## Initial Issues
 
-These are created automatically at bootstrap. Each is an orchestrator issue — it either requires a direct action (e.g. configure secrets) or it triggers the AI to produce a spec/PR that kicks off the next phase.
+These are created automatically by `init-issues.mjs`. Each is an orchestrator issue — it either requires a direct developer action or triggers Claude to produce a spec/PR that kicks off the next phase.
 
 | ID   | Title                                                             |
 |------|-------------------------------------------------------------------|
@@ -25,14 +25,14 @@ These are created automatically at bootstrap. Each is an orchestrator issue — 
 | [1b] | Set up branch policies                                            |
 | [1c] | Define high-level project spec, vision and external dependencies  |
 | [2a] | Generate UI/UX design issues from approved spec                   |
-| [3a] | Generate frontend user stories from approved UI/UX designs        |
-| [3b] | Create frontend GitHub issues from user story spec                |
+| [3a] | Frontend tech decisions + user story spec                         |
+| [3b] | Create frontend issues + backend skeleton                         |
 | [5a] | Create backend design spec                                        |
 | [5b] | Generate backend user stories from approved backend design        |
 | [5c] | Create backend GitHub issues from user story spec                 |
 | [6a] | Hook up Postgres DB (if required)                                 |
 | [7a] | Share MVP — publish YouTube walkthrough and gather user feedback  |
-| [7b] | Create production refinement tickets *(confirm user interest before actioning)* |
+| [7b] | Create production refinement tickets *(confirm developer interest before actioning)* |
 
 > **Phase 4 has no initial issues** — it consists entirely of implementation issues created by [3b].
 > **Phase 6 has no initial issues** — it consists entirely of implementation issues created by [5c], plus [6a] if Postgres is required.
@@ -49,13 +49,11 @@ A letter suffix identifies an orchestrator issue. These are the initial issues c
 - `[5b]` — second orchestrator issue in Phase 5
 
 ### Implementation issues — `[N]`
-Issues created dynamically *as a result of* an orchestrator issue carry only the phase number (no letter). These are the individual units of work the AI picks up and implements.
+Issues created dynamically *as a result of* an orchestrator issue carry only the phase number (no letter). These are the individual units of work Claude picks up and implements.
 
 - `[2] Auth page design` — a UI/UX design issue created by `[2a]`
 - `[4] Auth page` — a frontend implementation issue created by `[3b]`
 - `[6] Auth endpoint` — a backend implementation issue created by `[5c]`
-
-This distinction makes it immediately clear whether an issue is orchestrating a phase or implementing a piece of work within it.
 
 ---
 
@@ -65,11 +63,11 @@ This distinction makes it immediately clear whether an issue is orchestrating a 
 
 | Issue | Action |
 |-------|--------|
-| [1a] | Developer (or AI where possible) configures CI/CD pipeline secrets and variables in repository settings → closed |
-| [1b] | Developer configures branch protection rules for `main` and `dev` → closed |
-| [1c] | Developer fills in the spec questionnaire (see below), then adds the `waiting-for-ai` label. AI raises a **spec PR** containing the project vision, epics, features, and external dependencies. If anything is ambiguous, the AI leaves a PR comment and swaps the label to `waiting-for-human`. Developer reviews, iterates, merges → closed |
+| [1a] | Developer configures CI/CD pipeline secrets and variables → closed |
+| [1b] | Developer configures branch protection rules → closed |
+| [1c] | Developer fills in the spec questionnaire in the issue body, then comments `@claude [1c] is ready — please raise the spec PR`. Claude raises a **spec PR** containing the project vision, epics, features, and external dependencies. Developer reviews and merges → closed |
 
-**[1c] Spec questionnaire — the AI expects answers to:**
+**[1c] Spec questionnaire — Claude expects answers to:**
 - What problem does this product solve, and for whom?
 - What does a successful MVP look like?
 - Is Postgres required? If so, any schema/domain hints?
@@ -83,10 +81,10 @@ This distinction makes it immediately clear whether an issue is orchestrating a 
 
 | Issue | Action |
 |-------|--------|
-| [2a] | Triggered once [1c] is merged. AI scans the spec for features, creates one `[2] Feature name design` issue per feature. → [2a] closed |
-| [2] *per feature* | AI raises a **design PR** with ASCII mockups and Mermaid workflow diagrams. Developer reviews → merges or requests changes → issue closed on merge |
+| [2a] | Once [1c] is merged, comment `@claude [2a] is ready — please create the design issues`. Claude scans `docs/features/` and creates one `[2] Feature name design` issue per frontend feature → [2a] closed |
+| [2] *per feature* | Comment `@claude implement this design issue` on each. Claude raises a **design PR** with ASCII mockups and Mermaid workflow diagrams. Developer reviews → merges or requests changes → issue closed on merge |
 
-**[2] issue structure — what the AI puts in each design issue body:**
+**[2] issue structure — what Claude puts in each design issue body:**
 
 ```
 Design the <feature name> for <product name>.
@@ -94,7 +92,6 @@ Design the <feature name> for <product name>.
 **Feature:** `docs/features/<feature-file>.md`
 
 **Open UX questions to resolve:**
-- <question from feature file>
 - <question from feature file>
 
 **Deliverables (in the design PR):**
@@ -104,43 +101,30 @@ Design the <feature name> for <product name>.
 - [ ] All open UX questions answered
 ```
 
-**[2] design PR — what the AI produces:**
-- One ASCII mockup per page state and interaction state
-- One Mermaid sequence/flowchart diagram per key user action (shows what the system does, what data flows, what side effects occur)
-- Answers to all open UX questions listed in the issue
-- Sign-off checklist in the PR body for the developer to review before merge
-
 ---
 
 ### Phase 3 — Frontend User Stories & Issues
 
-> **BDD (Behaviour-Driven Development)** — a format for writing requirements as human-readable scenarios. Each story follows the pattern: *who* wants to do *what* and *why*, with concrete acceptance criteria that define when the story is done.
+> **BDD (Behaviour-Driven Development)** — requirements written as human-readable scenarios: *who* wants to do *what* and *why*, with concrete acceptance criteria defining when the story is done.
 
 | Issue | Action |
 |-------|--------|
-| [3a] | Triggered once all `[2]` issues are closed. AI raises a **spec PR** with three parts: **(A)** `docs/tech-decisions-frontend.md` — proposed library choices with rationale; **(B)** `docs/user-stories-frontend.md` — BDD stories derived from the signed-off designs; **(C)** API skeleton — endpoint contracts, response shapes, and RTK Query hooks table. Human review gate — developer must approve before merge → closed |
-| [3b] | Triggered once [3a] is merged. AI does two things: **(1)** creates individual `[4] Feature name` frontend implementation issues (closely related stories may be grouped into one issue); **(2)** raises a **backend skeleton PR** implementing the API contracts from [3a] using `Bogus` (Faker for .NET) — real HTTP endpoints, no service layer, deterministic seeded data. → closed |
+| [3a] | Once all `[2]` issues are closed, comment `@claude [3a] is ready — please raise the frontend tech decisions and user story spec PR`. Claude raises a **spec PR** with: `docs/tech-decisions-frontend.md` (library choices) and `docs/user-stories-frontend.md` (BDD stories + API skeleton contracts). Developer reviews → merges → closed |
+| [3b] | Once [3a] is merged, comment `@claude [3b] is ready`. Claude **(1)** creates `[4]` frontend implementation issues and **(2)** raises a **backend skeleton PR** with Bogus-generated endpoints matching the API contracts → closed |
 
-**[3a] spec PR — what the AI produces:**
+**[3a] spec PR — what Claude produces:**
 - `docs/tech-decisions-frontend.md` — library choices (UI component lib, chart lib, date handling, other deps)
-- `docs/user-stories-frontend.md` — BDD stories with acceptance criteria referencing the chosen libraries
-- API skeleton section in the stories doc: endpoint contracts (path, params, response shapes), RTK Query hooks table
-
-**[3a] tech decisions — the AI proposes choices for:**
-- UI component library (e.g. shadcn/ui, MUI, Mantine, Radix UI, or none)
-- Chart / visualisation library (e.g. Recharts, Chart.js, Nivo, Visx, D3)
-- Date handling (e.g. date-fns, dayjs, native `Intl`/Temporal)
-- Any other notable runtime dependencies specific to the project
+- `docs/user-stories-frontend.md` — BDD stories with acceptance criteria + API skeleton contracts
 
 ---
 
 ### Phase 4 — Frontend Implementation
 
-No initial issues. All work is driven by `[4]` issues created by [3b]. The backend skeleton (Faker endpoints) is already running — frontend makes real HTTP calls throughout.
+No initial issues. All work is driven by `[4]` issues created by [3b].
 
 | Issue | Action |
 |-------|--------|
-| [4] *per story* | AI writes Vitest + RTL tests first (AC items → test cases), then implements the component/feature to make them pass. Raises a **feature PR** with `Closes #N` in the body and a comment on the issue. Developer reviews → merges → issue auto-closes |
+| [4] *per story* | Comment `@claude implement this issue` on each. Claude writes Vitest + RTL tests first, then implements the component/feature. Raises a **feature PR** with `Closes #N`. Developer reviews → merges → issue auto-closes |
 
 ---
 
@@ -148,9 +132,9 @@ No initial issues. All work is driven by `[4]` issues created by [3b]. The backe
 
 | Issue | Action |
 |-------|--------|
-| [5a] | Triggered once all `[4]` issues are closed. AI raises a **backend design PR** covering data models, API contracts, EF Core entities, service architecture, and ER diagram in Mermaid. Developer reviews → merges → closed |
-| [5b] | Triggered once [5a] is merged. AI raises a **backend user story spec PR**. Human review gate → merge → closed |
-| [5c] | Triggered once [5b] is merged. AI creates individual `[5] Feature name` backend implementation issues → closed |
+| [5a] | Once all `[4]` issues are closed, comment `@claude [5a] is ready — please raise the backend design spec`. Claude raises a **backend design PR** covering data models, API contracts, EF Core entities, service architecture, and ER diagram in Mermaid → closed |
+| [5b] | Once [5a] is merged, comment `@claude [5b] is ready`. Claude raises a **backend user story spec PR** → closed |
+| [5c] | Once [5b] is merged, comment `@claude [5c] is ready`. Claude creates individual `[6]` backend implementation issues → closed |
 
 ---
 
@@ -158,19 +142,17 @@ No initial issues. All work is driven by `[4]` issues created by [3b]. The backe
 
 | Issue | Action |
 |-------|--------|
-| [6a] | Triggered once all `[5]` issues are closed. AI wires up Postgres — schema, EF Core migrations, connection config — and raises a PR. Skipped if Postgres was marked not required in [1c] → closed |
-| [6] *per story* | AI implements the backend story (TDD: unit tests first), raises a **feature PR** with `Closes #N` and a comment on the issue. Developer reviews → merges → issue auto-closes |
+| [6a] | Once all `[6]` issues are closed, comment `@claude [6a] is ready`. Claude wires up Postgres — schema, EF Core migrations, connection config — and raises a PR. Skipped if Postgres was marked not required in [1c] → closed |
+| [6] *per story* | Comment `@claude implement this issue` on each. Claude implements TDD (unit tests first), raises a **feature PR** with `Closes #N`. Developer reviews → merges → issue auto-closes |
 
 ---
 
 ### Phase 7 — MVP 🎉
 
-Formal phases end here. Post-MVP work is informal and developer-led.
-
 | Issue | Action |
 |-------|--------|
-| [7a] | AI drafts a YouTube script and walthrough outline for the MVP. Developer records and publishes |
-| [7b] | AI generates production refinement tickets (performance, security, scaling, testing gaps). ⚠️ **Confirm user interest before actioning these** |
+| [7a] | Comment `@claude [7a] is ready`. Claude drafts a YouTube walkthrough script as `docs/mvp-walkthrough-script.md` via a PR. Developer records and publishes |
+| [7b] | Comment `@claude [7b] is ready — please generate refinement tickets`. Claude audits the codebase and raises targeted issues for performance, security, and test coverage gaps. ⚠️ **Only action when explicitly requested** |
 
 ---
 
@@ -178,67 +160,23 @@ Formal phases end here. Post-MVP work is informal and developer-led.
 
 | Branch | Purpose |
 |---|---|
-| `main` | Production-ready code only — merged from `dev` by the **human developer** when a milestone is complete |
+| `main` | Production-ready code only — merged from `dev` by the **developer** when a milestone is complete |
 | `dev` | Integration branch — **all feature/spec/docs PRs target `dev`** |
 | `feat/*`, `fix/*`, `spec/*`, `docs/*` | Short-lived work branches — always branch from `dev`, always PR back to `dev` |
 
-**Never PR directly to `main`.** The AI always sets `dev` as the base branch when raising PRs.
+**Never PR directly to `main`.** Claude always sets `dev` as the base branch when raising PRs.
 
-**`dev` → `main` is a human-only action.** The AI never raises a PR targeting `main` and never merges `dev` into `main`. This is a deliberate gate — the developer decides when a milestone is production-ready.
+**`dev` → `main` is a human-only action.** Claude never raises a PR targeting `main` and never merges `dev` into `main`.
 
 ---
 
 ## PR ↔ Issue Linking
 
-When the AI raises a PR for an issue, it does three things:
+When Claude raises a PR for an issue, it does three things:
 
-1. **`Closes #N` in the PR body** — GitHub automatically closes the issue when the PR is merged and shows the link in both the PR and issue sidebars.
-2. **Comment on the issue** — The AI posts a comment on the issue itself:
-   > 🤖 PR raised: #42 — please review when ready.
-3. **Assign the PR to the repo owner** — Every PR is assigned to `jemmy8oy` so it appears in the developer's assigned PRs list and is easy to find.
-
-This means anyone watching the issue gets notified and can navigate to the PR without searching for it.
-
----
-
-## Agent Conventions
-
-### Label-driven turns
-
-Labels signal whose turn it is to act. The AI monitors for `waiting-for-ai` on both issues and PRs.
-
-**On issues:**
-- Developer adds `waiting-for-ai` → AI picks up, responds or raises a PR, then swaps to `waiting-for-human`
-- Developer adds `action-ready` → AI implements without discussion, raises a PR, removes `action-ready`
-- If the AI has a blocking question when it sees `action-ready`, it removes `action-ready`, adds `waiting-for-human`, and posts the question as a comment. Developer answers and re-applies `action-ready` to proceed.
-
-**On PRs:**
-- Developer leaves a review and adds `waiting-for-ai` → AI addresses comments, pushes, swaps to `waiting-for-human`
-- No `action-ready` on PRs — a PR is already an implementation artefact
-
-**No labels = idle/backlog.** An issue without labels is simply waiting — neither the AI nor the developer is blocked.
-
-### "Iterate" shorthand
-
-When the developer sends `iterate`, `iterate issue`, or `iterate pr`, the AI will:
-
-1. Fetch the most recently active open issue or PR
-2. Read all new comments/activity since the last response
-3. Reply or act accordingly
-
-This is a lightweight text-based trigger for use alongside the label system.
-
----
-
-## Labels
-
-| Label | Usage |
-|-------|-------|
-| `waiting-for-ai` | AI's turn — discussion, spec iteration, or PR review iteration |
-| `waiting-for-human` | Human's turn — reviewing, providing input, or signing off |
-| `action-ready` | Issue approved for implementation — AI should start coding |
-
-Labels apply to both issues and PRs. No label = idle/backlog.
+1. **`Closes #N` in the PR body** — GitHub automatically closes the issue when the PR is merged.
+2. **Comment on the issue** — Claude posts: *🤖 PR raised: #N — please review when ready.*
+3. **Assign the PR to the repo owner** — every PR is assigned so it appears in the developer's assigned PRs list.
 
 ---
 

--- a/scripts/init-issues.mjs
+++ b/scripts/init-issues.mjs
@@ -34,27 +34,6 @@ function ghSilent(args) {
   }
 }
 
-// ── Labels ────────────────────────────────────────────────────────────────────
-
-const LABELS = [
-  { name: 'waiting-for-ai',    color: '2ea44f', description: "AI's turn — discussion, spec iteration, or PR review" },
-  { name: 'waiting-for-human', color: '0075ca', description: "Human's turn — reviewing, providing input, or signing off" },
-  { name: 'action-ready',      color: '7057ff', description: 'Issue approved for implementation — AI should start coding' },
-];
-
-function ensureLabels() {
-  log('Creating labels...');
-  for (const label of LABELS) {
-    const existing = ghSilent(`label list --search "${label.name}" --json name -q ".[0].name"`);
-    if (existing === label.name) {
-      log(`  Label "${label.name}" already exists — skipping`);
-    } else {
-      gh(`label create "${label.name}" --color "${label.color}" --description "${label.description}"`);
-      log(`  Created label "${label.name}"`);
-    }
-  }
-}
-
 // ── Milestone ─────────────────────────────────────────────────────────────────
 
 const MILESTONE_TITLE = 'MVP';
@@ -78,7 +57,7 @@ const ISSUES = [
     title: '[1a] Set up pipeline secrets and variables',
     body: `## Summary
 
-Configure CI/CD pipeline secrets and repository variables so automated workflows can build and deploy the app.
+Configure CI/CD pipeline secrets and repository variables so automated workflows can build, deploy, and run Claude.
 
 ## Acceptance Criteria
 
@@ -88,25 +67,26 @@ Configure CI/CD pipeline secrets and repository variables so automated workflows
 - [ ] Repository **Secrets** added (Settings → Secrets and variables → Secrets):
   - \`OCIR_USERNAME\` — e.g. \`tenancy/oracleidentitycloudservice/your@email.com\`
   - \`OCIR_AUTH_TOKEN\` — OCI auth token
+  - \`CLAUDE_CODE_OAUTH_TOKEN\` — OAuth token for the Claude GitHub Action
 
-## AI Notes
+## Notes
 
-This issue is actioned by the developer, not the AI. Close it once secrets are configured.
+This issue is actioned by the developer, not Claude. Close it once secrets are configured.
 `,
   },
   {
     title: '[1b] Set up branch policies',
     body: `## Summary
 
-Configure branch protection rules so that \`main\` is developer-only and all agent work flows through \`dev\` via PRs.
+Configure branch protection rules so that \`main\` is developer-only and all work flows through \`dev\` via PRs.
 
 ## Acceptance Criteria
 
 - [ ] \`main\` branch created and protected (require PR, no direct push)
-- [ ] \`dev\` branch created — default branch for agent PRs
+- [ ] \`dev\` branch created — default branch for Claude PRs
 - [ ] **"Automatically delete head branches"** enabled (Settings → General)
 
-## AI Notes
+## Notes
 
 This issue is actioned by the developer. Close it once branch policies are in place.
 `,
@@ -115,19 +95,19 @@ This issue is actioned by the developer. Close it once branch policies are in pl
     title: '[1c] Define high-level project spec, vision and external dependencies',
     body: `## Summary
 
-Capture the product vision and scope so the AI can produce the first spec PR — covering epics, features, and external dependencies.
+Capture the product vision and scope so Claude can produce the first spec PR — covering epics, features, and external dependencies.
 
 ## Acceptance Criteria
 
 - [ ] Spec questionnaire completed (see below)
-- [ ] \`ai-ready\` label applied to this issue
-- [ ] AI raises a spec PR with vision statement, \`docs/epics/\`, \`docs/features/\`, and dependency notes
-- [ ] All ambiguities resolved via PR comments or \`needs-input\` issues
+- [ ] Developer comments \`@claude [1c] is ready — please raise the spec PR\` on this issue
+- [ ] Claude raises a spec PR with vision statement, \`docs/epics/\`, \`docs/features/\`, and dependency notes
+- [ ] All ambiguities resolved via PR comments
 - [ ] Spec PR reviewed and merged by developer
 
 ## Spec Questionnaire
 
-Please answer the following, then add the \`ai-ready\` label:
+Please answer the following, then tag \`@claude\` to proceed:
 
 - **What problem does this product solve, and for whom?**
 
@@ -141,12 +121,11 @@ Please answer the following, then add the \`ai-ready\` label:
 
 - **What is explicitly out of scope for the MVP?**
 
-## AI Notes
+## When tagged with \`@claude\`
 
-When this issue is labelled \`ai-ready\`:
 1. Read the questionnaire answers above
 2. Raise a spec PR containing: vision statement, \`docs/epics/*.md\`, \`docs/features/*.md\`, out-of-scope list, and external dependency notes
-3. Leave a PR comment for anything ambiguous — if unresolved after one round, open a \`needs-input\` issue
+3. Leave a PR comment for anything ambiguous
 `,
   },
   {
@@ -167,7 +146,7 @@ Depends on [1c] spec PR being merged.
 
 ## [2] Issue structure
 
-Each \`[2]\` issue the AI creates must follow this format:
+Each \`[2]\` issue must follow this format:
 
 \`\`\`
 Design the <feature name> for <product name>.
@@ -175,7 +154,6 @@ Design the <feature name> for <product name>.
 **Feature:** \`docs/features/<feature-file>.md\`
 
 **Open UX questions to resolve:**
-- <question from feature file>
 - <question from feature file>
 
 **Deliverables (in the design PR):**
@@ -185,37 +163,52 @@ Design the <feature name> for <product name>.
 - [ ] All open UX questions answered
 \`\`\`
 
-## AI Notes
+## When tagged with \`@claude\`
 
-Trigger: [1c] PR merged.
-Action: Read \`docs/features/\`, create one \`[2] <Feature> design\` issue per frontend feature using the structure above, assign each to the repo owner, then close this issue.
+Read \`docs/features/\`, create one \`[2] <Feature> design\` issue per frontend feature using the structure above, assign each to the repo owner, then close this issue.
 `,
   },
   {
     title: '[3a] Frontend tech decisions + user story spec',
-    body: `## Summary
+    body: `## [3a] — Frontend Tech Decisions & Stories
 
-Once all \`[2]\` design issues are closed, raise a spec PR covering three things:
+The AI raises a single PR containing two documents. Before raising the PR, the five sections below must all be addressed:
 
-**Part A — Frontend tech decisions** (\`docs/tech-decisions-frontend.md\`)
-Propose and justify library choices before implementation begins:
-- UI component library (e.g. shadcn/ui, MUI, Mantine, Radix UI, or none)
-- Chart / visualisation library (e.g. Recharts, Chart.js, Nivo, Visx, D3)
-- Date handling (e.g. date-fns, dayjs, native \`Intl\`/Temporal)
-- Any other notable runtime dependencies
+### 1. Library choices
+- UI component library (e.g. shadcn/ui, Radix, Mantine)
+- Chart library (e.g. Recharts, Nivo, Chart.js)
+- Date handling library (e.g. date-fns, dayjs)
+- State management approach (RTK Query + Redux Toolkit, or other)
 
-**Part B — BDD user stories** (\`docs/user-stories-frontend.md\`)
-BDD (Behaviour-Driven Development) stories derived from the signed-off designs:
-*As a [persona], I want to [action] so that [outcome]* — with acceptance criteria referencing specific UI states from the ASCII mockups.
+### 2. API skeleton contracts
+- Endpoint shapes (URL, method, response type)
+- RTK Query hook definitions
+- TypeScript response types
 
-**Part C — API skeleton**
-Endpoint contracts (path, params, response shapes) and RTK Query hooks table — included in the user stories doc. Defines what the backend skeleton must implement.
+### 3. Fake data strategy
+- How does the frontend get data before the real backend exists?
+- Preferred: Faker backend skeleton (confirmed or proposed)
+- Alternative: MSW (Mock Service Worker) — if Faker backend not viable
+
+### 4. Frontend TDD approach
+- Test framework: Vitest + React Testing Library
+- Test-before-component approach (spec-first)
+- One test file per component covering key behaviours
+
+### 5. BDD user stories
+- Definition: *"As [role], I want [action], so that [benefit]"*
+- One story per user workflow
+- Acceptance criteria per story (Given/When/Then or checklist)
+
+**Both documents (\`docs/tech-decisions-frontend.md\` and \`docs/user-stories-frontend.md\`) must cover all five areas before the PR is raised.**
 
 ## Acceptance Criteria
 
-- [ ] \`docs/tech-decisions-frontend.md\` — library proposals with rationale
+- [ ] \`docs/tech-decisions-frontend.md\` — library choices with rationale
 - [ ] \`docs/user-stories-frontend.md\` — BDD stories for every signed-off design
-- [ ] API skeleton section — endpoint contracts + RTK Query hooks table
+- [ ] API skeleton contracts included — endpoint shapes, RTK Query hooks, TypeScript types
+- [ ] Fake data strategy documented
+- [ ] Frontend TDD approach defined
 - [ ] Human review gate — developer must approve before merge
 - [ ] This issue closed on merge
 
@@ -223,10 +216,9 @@ Endpoint contracts (path, params, response shapes) and RTK Query hooks table —
 
 Depends on all \`[2]\` design issues being closed.
 
-## AI Notes
+## When tagged with \`@claude\`
 
-Trigger: all \`[2]\` issues closed.
-Action: Raise a single PR with \`docs/tech-decisions-frontend.md\` (library proposals) and \`docs/user-stories-frontend.md\` (BDD stories + API skeleton). Stories reference chosen libraries where relevant (e.g. "chart renders using Recharts"). API skeleton documents response shapes as TypeScript interfaces and lists RTK Query hooks.
+Raise a single PR with \`docs/tech-decisions-frontend.md\` (library choices, fake data strategy, TDD approach) and \`docs/user-stories-frontend.md\` (BDD stories + API skeleton contracts). All five sections must be addressed before the PR is raised.
 `,
   },
   {
@@ -252,10 +244,9 @@ Implement the API contracts from the [3a] spec as real ASP.NET Core Minimal API 
 
 Depends on [3a] PR being merged.
 
-## AI Notes
+## When tagged with \`@claude\`
 
-Trigger: [3a] PR merged.
-Action: (1) Read \`docs/user-stories-frontend.md\`, create \`[4]\` issues, update \`docs/features/*.md\`. (2) Raise a backend skeleton PR implementing the two endpoints (\`GET /api/metrics/ratio\` and \`GET /api/metrics/indicator/:id\`) with Bogus-generated data in \`MacroMetrics.WebApi\`.
+(1) Read \`docs/user-stories-frontend.md\`, create \`[4]\` issues, update \`docs/features/*.md\`. (2) Raise a backend skeleton PR implementing the API endpoints with Bogus-generated data in the WebApi project.
 `,
   },
   {
@@ -275,14 +266,25 @@ Once all frontend implementation issues (\`[4]\`) are closed, raise a backend de
 - [ ] Developer reviews and merges
 - [ ] This issue closed on merge
 
+## Data Source Validation (required before writing implementation issues)
+
+For each external data source listed in [1c]:
+
+- [ ] Confirm the API endpoint and series ID exist and are accessible (curl the endpoint — do not assume)
+- [ ] Document the exact URL pattern used
+- [ ] Note rate limits and API key requirements
+- [ ] Record the data cadence (daily / monthly / quarterly) and earliest available date
+- [ ] Flag any sources that could not be validated with ⚠️ and explain why
+
+**Do not write any [6] fetcher implementation issues until all data sources in scope have been validated.**
+
 ## Dependencies
 
 Depends on all \`[4]\` frontend issues being closed.
 
-## AI Notes
+## When tagged with \`@claude\`
 
-Trigger: all \`[4]\` issues closed.
-Action: Raise a backend design PR. The OpenAPI spec generated from the skeleton app is the source of truth for API contracts. Follow \`docs/specs/backend-architecture.md\` and \`docs/specs/backend-srp.md\`.
+Raise a backend design PR. The OpenAPI spec generated from the skeleton app is the source of truth for API contracts. Follow \`docs/specs/backend-architecture.md\` and \`docs/specs/backend-srp.md\`.
 `,
   },
   {
@@ -301,10 +303,9 @@ Once the backend design PR from [5a] is merged, raise a backend user story spec 
 
 Depends on [5a] PR being merged.
 
-## AI Notes
+## When tagged with \`@claude\`
 
-Trigger: [5a] PR merged.
-Action: Raise a PR adding \`docs/user-stories-backend.md\` with BDD-style stories derived from the API contracts and backend design.
+Raise a PR adding \`docs/user-stories-backend.md\` with BDD-style stories derived from the API contracts and backend design.
 `,
   },
   {
@@ -316,18 +317,26 @@ Once the backend user story spec PR from [5b] is merged, create individual \`[6]
 ## Acceptance Criteria
 
 - [ ] One \`[6] <Story>\` issue created per story in the merged backend user story spec
-- [ ] Each issue uses the **User Story** issue template
 - [ ] \`docs/features/*.md\` updated with the GH issue numbers
 - [ ] This issue closed once all \`[6]\` issues are created
+
+## [6] Issue structure
+
+Each \`[6]\` issue must include:
+
+\`\`\`
+## Before implementing
+
+Confirm the series ID and API endpoint from the Phase 5 data source validation notes in \`[5a]\`. If validation notes are absent, run the validation step before writing any code.
+\`\`\`
 
 ## Dependencies
 
 Depends on [5b] PR being merged.
 
-## AI Notes
+## When tagged with \`@claude\`
 
-Trigger: [5b] PR merged.
-Action: Read \`docs/user-stories-backend.md\`, create one \`[6] <Story>\` issue per story, update \`docs/features/*.md\` with issue numbers, then close this issue.
+Read \`docs/user-stories-backend.md\`, create one \`[6] <Story>\` issue per story, update \`docs/features/*.md\` with issue numbers, then close this issue.
 `,
   },
   {
@@ -345,12 +354,11 @@ Wire up the real Postgres database — EF Core migrations, connection config, an
 
 ## Dependencies
 
-Depends on all \`[5]\` backend implementation issues being closed.
+Depends on all \`[6]\` backend implementation issues being closed.
 
-## AI Notes
+## When tagged with \`@claude\`
 
-Trigger: all \`[6]\` issues closed (or skip if Postgres was marked not required in [1c]).
-Action: Scaffold EF Core migrations, wire connection string from K8s secret, raise a PR.
+Scaffold EF Core migrations, wire connection string from K8s secret, raise a PR. Skip if Postgres was marked not required in [1c].
 `,
   },
   {
@@ -361,7 +369,7 @@ Draft a YouTube walkthrough script and outline for the MVP launch.
 
 ## Acceptance Criteria
 
-- [ ] AI drafts a walkthrough script covering key features and user journeys
+- [ ] Claude drafts a walkthrough script covering key features and user journeys as \`docs/mvp-walkthrough-script.md\`
 - [ ] Developer records and publishes the video
 - [ ] Feedback gathered from initial users
 
@@ -369,10 +377,9 @@ Draft a YouTube walkthrough script and outline for the MVP launch.
 
 Depends on [6a] (or all backend stories) being merged.
 
-## AI Notes
+## When tagged with \`@claude\`
 
-Trigger: MVP is deployed and stable.
-Action: Draft a YouTube script with an intro, feature walkthrough sections, and a call to action. Structure it as a \`docs/mvp-walkthrough-script.md\` PR.
+Draft a YouTube script with an intro, feature walkthrough sections, and a call to action. Raise it as a PR adding \`docs/mvp-walkthrough-script.md\`.
 `,
   },
   {
@@ -389,11 +396,10 @@ Generate production refinement tickets covering performance, security, scaling, 
 
 Depends on [7a].
 
-## AI Notes
+## When tagged with \`@claude\`
 
-⚠️ **Confirm developer interest before actioning this issue.**
-Trigger: Developer explicitly asks the AI to action this.
-Action: Audit the codebase and raise targeted issues for: N+1 queries, missing indexes, auth hardening, rate limiting, load testing, and any coverage gaps identified during implementation.
+⚠️ **Only action when the developer explicitly asks.**
+Audit the codebase and raise targeted issues for: N+1 queries, missing indexes, auth hardening, rate limiting, load testing, and any coverage gaps identified during implementation.
 `,
   },
 ];
@@ -404,10 +410,11 @@ async function run() {
   log('Scaffolding initial SDD issues...');
   log('');
 
-  ensureLabels();
+  const milestone = ensureMilestone();
   log('');
 
-  const milestone = ensureMilestone();
+  const owner = gh('repo view --json owner --jq .owner.login');
+  log(`Repo owner: ${owner}`);
   log('');
 
   log(`Creating ${ISSUES.length} orchestrator issues...`);
@@ -421,7 +428,7 @@ async function run() {
     const bodyFile = join(tmpdir(), `issue-body-${Date.now()}.md`);
     writeFileSync(bodyFile, issue.body);
 
-    gh(`issue create --title "${issue.title}" --body-file "${bodyFile}" --milestone "${milestone}"`);
+    gh(`issue create --title "${issue.title}" --body-file "${bodyFile}" --milestone "${milestone}" --assignee "${owner}"`);
     log(`  CREATED  "${issue.title}"`);
 
     try { unlinkSync(bodyFile); } catch { /* ignore */ }
@@ -429,7 +436,7 @@ async function run() {
 
   log('');
   log('✅ Done. All initial SDD issues created.');
-  log('   Next step: work through Phase 1 issues, then add the waiting-for-ai label to [1c] once the spec questionnaire is complete.');
+  log('   Next step: work through Phase 1 issues ([1a], [1b]), then fill in the [1c] spec questionnaire and comment @claude to proceed.');
 }
 
 run().catch(err => {


### PR DESCRIPTION
## Summary

- Replaces label-based trigger system with `@claude` GitHub Action mentions
- Inlines `action-issue`, `respond-to-pr`, and `pr-readiness` skill content directly into `CLAUDE.md`
- Removes `[1d]`/`[1e]` phases, multi-pass/self-relabelling conventions, and hardcoded assignee
- Adds `CLAUDE_CODE_OAUTH_TOKEN` to `[1a]` issue scaffold and dynamic assignee lookup
- Creates `.agents/rules/project.md` (was missing from this repo)
- Adds `.github/workflows/claude.yml` to enable `@claude` mentions in issues and PRs

## Assumptions & Decisions

| # | Assumption | Rationale | If incorrect... |
|---|---|---|---|
| 1 | `dev` is the correct PR target | Matches branch strategy in all other repos | Retarget the PR |
| 2 | `.agents/rules/project.md` should be created to match the template | CLAUDE.md references it but the file was missing | Remove the reference instead |