### PR TITLE
Add GitOps values.yaml update to build pipeline

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -16,10 +16,20 @@ jobs:
     runs-on: ubuntu-24.04-arm  # Native ARM64 runner — no QEMU emulation overhead
 
     steps:
+      # --- 1. GENERATE SHORT-LIVED GITOPS BOT TOKEN ---
+      - name: Generate GitOps Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.GIT_OPS_APP_ID }}
+          private-key: ${{ secrets.GITOPS_APP_PRIVATE_KEY }}
+
+      # --- 2. CHECKOUT CODE USING THE APP TOKEN ---
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Required for GitVersion to read full git history
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v1
@@ -40,19 +50,7 @@ jobs:
           username: ${{ secrets.OCIR_USERNAME }}
           password: ${{ secrets.OCIR_AUTH_TOKEN }}
 
-      - name: Build and push Frontend
-        uses: docker/build-push-action@v5
-        with:
-          context: ./frontend
-          push: true
-          provenance: false
-          sbom: false
-          tags: |
-            ${{ vars.OCIR_REGISTRY }}/${{ vars.OCIR_NAMESPACE }}/${{ env.FRONTEND_IMAGE }}:latest
-            ${{ vars.OCIR_REGISTRY }}/${{ vars.OCIR_NAMESPACE }}/${{ env.FRONTEND_IMAGE }}:${{ steps.gitversion.outputs.semVer }}
-          cache-from: type=gha,scope=frontend
-          cache-to: type=gha,mode=max,scope=frontend
-
+      # --- 3. BUILD & PUSH BACKEND ---
       - name: Build and push Backend
         uses: docker/build-push-action@v5
         with:
@@ -66,6 +64,21 @@ jobs:
           cache-from: type=gha,scope=backend
           cache-to: type=gha,mode=max,scope=backend
 
+      # --- 4. BUILD & PUSH FRONTEND ---
+      - name: Build and push Frontend
+        uses: docker/build-push-action@v5
+        with:
+          context: ./frontend
+          push: true
+          provenance: false
+          sbom: false
+          tags: |
+            ${{ vars.OCIR_REGISTRY }}/${{ vars.OCIR_NAMESPACE }}/${{ env.FRONTEND_IMAGE }}:latest
+            ${{ vars.OCIR_REGISTRY }}/${{ vars.OCIR_NAMESPACE }}/${{ env.FRONTEND_IMAGE }}:${{ steps.gitversion.outputs.semVer }}
+          cache-from: type=gha,scope=frontend
+          cache-to: type=gha,mode=max,scope=frontend
+
+      # --- 5. BUILD & PUSH SIDECAR ---
       - name: Build and push Sidecar
         uses: docker/build-push-action@v5
         with:
@@ -78,3 +91,34 @@ jobs:
             ${{ vars.OCIR_REGISTRY }}/${{ vars.OCIR_NAMESPACE }}/${{ env.SIDECAR_IMAGE }}:${{ steps.gitversion.outputs.semVer }}
           cache-from: type=gha,scope=sidecar
           cache-to: type=gha,mode=max,scope=sidecar
+
+      # --- 6. THE GITOPS AUTO-UPDATE LOOP ---
+      - name: Install yq (YAML Processor)
+        uses: mikefarah/yq@v4.44.1
+
+      - name: Update Helm Chart Values File
+        run: |
+          NEW_VERSION="${{ steps.gitversion.outputs.semVer }}"
+          VALUES_FILE="helm/values.yaml"
+
+          echo "Patching array image tags in $VALUES_FILE to version: $NEW_VERSION"
+
+          yq -i '(.apps[] | select(.name == "backend") | .image.tag) = "'"$NEW_VERSION"'"' $VALUES_FILE
+          yq -i '(.apps[] | select(.name == "frontend") | .image.tag) = "'"$NEW_VERSION"'"' $VALUES_FILE
+          yq -i '(.apps[] | select(.name == "yfinance-sidecar") | .image.tag) = "'"$NEW_VERSION"'"' $VALUES_FILE
+
+      - name: Commit and Push Image Tag Changes
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add helm/values.yaml
+
+          if git diff --staged --quiet; then
+            echo "No manifest changes required. Version is already up to date."
+          else
+            git commit -m "chore(gitops): release version ${{ steps.gitversion.outputs.semVer }} [skip ci]"
+
+            # This cleanly pushes back using the App token set during checkout
+            git push origin HEAD
+          fi


### PR DESCRIPTION
## Summary

- Adds GitHub App token generation step so the pipeline can push back to the protected \`main\` branch
- Uses the app token during checkout so \`git push origin HEAD\` at the end is authorised
- Installs \`yq\` and patches \`helm/values.yaml\` image tags for \`backend\`, \`frontend\`, and \`yfinance-sidecar\` after images are pushed
- Commits the tag update back to \`main\` with \`[skip ci]\` to avoid a build loop

## Assumptions & Decisions

| # | Assumption | Rationale | If incorrect... |
|---|---|---|---|
| 1 | \`GIT_OPS_APP_ID\` and \`GITOPS_APP_PRIVATE_KEY\` are org-level vars/secrets | Matches holiday-planning setup | Add them at repo level instead |
| 2 | Helm app names are \`backend\`, \`frontend\`, \`yfinance-sidecar\` | Read from \`helm/values.yaml\` | Update the yq selectors in the patch step |